### PR TITLE
add `broken-release-refs` command

### DIFF
--- a/acceptance/broken_release_refs_test.go
+++ b/acceptance/broken_release_refs_test.go
@@ -1,0 +1,27 @@
+package acceptance
+
+import (
+	"os/exec"
+
+	"github.com/onsi/gomega/gexec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("broken-release-refs", func() {
+	It("prints a list of releases that are referenced but not in the tile", func() {
+		command := exec.Command(pathToMain, "--path", pathToBrokenReleaseRefsTile, "broken-release-refs")
+
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(session).Should(gexec.Exit(1))
+		Expect(string(session.Err.Contents())).To(ContainSubstring(`The following releases are referenced but not in the tile:
+new-diego (referenced by template "auctioneer" in "diego_brain" job)
+new-diego (referenced by template "some-job" in "diego_brain" job)
+capi-release (referenced by template "some-other-job" in "diego_brain" job)
+capi-release (referenced by template "some-cc-job" in "cloud_controller" job)
+`))
+	})
+})

--- a/acceptance/help_test.go
+++ b/acceptance/help_test.go
@@ -19,6 +19,7 @@ Usage: inspector [options] <command> [<args>]
 Commands:
   deadweight  something dead
   help        prints this usage information
+  pkg-dep     something dep
 `
 
 const HELP_USAGE = `inspector help

--- a/acceptance/help_test.go
+++ b/acceptance/help_test.go
@@ -17,9 +17,10 @@ Usage: inspector [options] <command> [<args>]
   -p, --path  string  path to the product file
 
 Commands:
-  deadweight  something dead
-  help        prints this usage information
-  pkg-dep     something dep
+  broken-release-refs  prints missing releases
+  deadweight           something dead
+  help                 prints this usage information
+  pkg-dep              something dep
 `
 
 const HELP_USAGE = `inspector help

--- a/commands/broken_release_refs.go
+++ b/commands/broken_release_refs.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+)
+
+type BrokenReleaseRefs struct {
+	productParser productParser
+}
+
+func NewBrokenReleaseRefs(productParser productParser) BrokenReleaseRefs {
+	return BrokenReleaseRefs{
+		productParser: productParser,
+	}
+}
+
+func (b BrokenReleaseRefs) Execute(args []string) error {
+	product, err := b.productParser.Parse()
+	if err != nil {
+		panic(err)
+	}
+
+	releases := map[string]bool{}
+	for _, release := range product.Releases {
+		releases[release.Name] = true
+	}
+
+	errMsgs := []string{}
+	for _, job := range product.Metadata.Jobs {
+		for _, template := range job.Templates {
+			if _, ok := releases[template.Release]; !ok {
+				errMsgs = append(errMsgs, fmt.Sprintf("%s (referenced by template %q in %q job)", template.Release, template.Name, job.Name))
+			}
+		}
+	}
+
+	if len(errMsgs) > 0 {
+		return fmt.Errorf("The following releases are referenced but not in the tile:\n%s\n", strings.Join(errMsgs, "\n"))
+	}
+
+	return nil
+}
+
+func (b BrokenReleaseRefs) Usage() Usage {
+	return Usage{
+		Description:      "prints releases that are referenced by job templates but not in tile",
+		ShortDescription: "prints missing releases",
+	}
+}

--- a/commands/broken_release_refs_test.go
+++ b/commands/broken_release_refs_test.go
@@ -1,0 +1,66 @@
+package commands_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/ryanmoran/inspector/commands"
+	"github.com/ryanmoran/inspector/commands/fakes"
+	"github.com/ryanmoran/inspector/tiles"
+)
+
+var _ = Describe("Broken-Release-Refs", func() {
+	Describe("Execute", func() {
+		It("finds references to releases that are not in the tile", func() {
+			productParser := &fakes.ProductParser{}
+			productParser.ParseCall.Returns.Product = tiles.Product{
+				Metadata: tiles.Metadata{
+					Jobs: []tiles.MetadataJob{
+						{
+							Name: "some_diego_job",
+							Templates: []tiles.MetadataJobTemplate{
+								{
+									Name:    "some-diego-job-template",
+									Release: "some-other-diego-release",
+								},
+								{
+									Name:    "some-capi-job-template-1",
+									Release: "some-other-capi-release",
+								},
+							},
+						},
+						{
+							Name: "some_capi_job",
+							Templates: []tiles.MetadataJobTemplate{
+								{
+									Name:    "some-capi-job-template-2",
+									Release: "some-other-capi-release",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			command := commands.NewBrokenReleaseRefs(productParser)
+
+			err := command.Execute([]string{})
+
+			Expect(productParser.ParseCall.CallCount).To(Equal(1))
+			Expect(err).To(MatchError(`The following releases are referenced but not in the tile:
+some-other-diego-release (referenced by template "some-diego-job-template" in "some_diego_job" job)
+some-other-capi-release (referenced by template "some-capi-job-template-1" in "some_diego_job" job)
+some-other-capi-release (referenced by template "some-capi-job-template-2" in "some_capi_job" job)
+`))
+		})
+	})
+
+	Describe("Usage", func() {
+		It("returns a descriptive usage", func() {
+			command := commands.NewBrokenReleaseRefs(nil)
+			Expect(command.Usage()).To(Equal(commands.Usage{
+				Description:      "prints releases that are referenced by job templates but not in tile",
+				ShortDescription: "prints missing releases",
+			}))
+		})
+	})
+})

--- a/commands/fakes/product_parser.go
+++ b/commands/fakes/product_parser.go
@@ -4,7 +4,8 @@ import "github.com/ryanmoran/inspector/tiles"
 
 type ProductParser struct {
 	ParseCall struct {
-		Returns struct {
+		CallCount int
+		Returns   struct {
 			Product tiles.Product
 			Error   error
 		}
@@ -12,5 +13,6 @@ type ProductParser struct {
 }
 
 func (p *ProductParser) Parse() (tiles.Product, error) {
+	p.ParseCall.CallCount++
 	return p.ParseCall.Returns.Product, p.ParseCall.Returns.Error
 }

--- a/commands/set.go
+++ b/commands/set.go
@@ -18,7 +18,7 @@ func (s Set) Execute(command string, args []string) error {
 
 	err := cmd.Execute(args)
 	if err != nil {
-		return fmt.Errorf("could not execute %q: %s", command, err)
+		return fmt.Errorf("%s", err)
 	}
 
 	return nil

--- a/commands/set_test.go
+++ b/commands/set_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Set", func() {
 					}
 
 					err := commandSet.Execute("erroring-command", []string{})
-					Expect(err).To(MatchError("could not execute \"erroring-command\": failed to execute"))
+					Expect(err).To(MatchError("failed to execute"))
 				})
 			})
 		})

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	stdout := log.New(os.Stdout, "", 0)
+	stderr := log.New(os.Stderr, "", 0)
 
 	var global struct {
 		Help bool   `short:"h" long:"help" description:"prints this usage information" default:"false"`
@@ -19,12 +19,12 @@ func main() {
 
 	args, err := flags.Parse(&global, os.Args[1:])
 	if err != nil {
-		stdout.Fatal(err)
+		stderr.Fatal(err)
 	}
 
 	globalFlagsUsage, err := flags.Usage(global)
 	if err != nil {
-		stdout.Fatal(err)
+		stderr.Fatal(err)
 	}
 
 	var command string
@@ -45,6 +45,6 @@ func main() {
 
 	err = commandSet.Execute(command, args)
 	if err != nil {
-		stdout.Fatal(err)
+		stderr.Fatal(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 	commandSet["help"] = commands.NewHelp(os.Stdout, globalFlagsUsage, commandSet)
 	commandSet["deadweight"] = commands.NewDeadweight(productParser, os.Stdout)
 	commandSet["pkg-dep"] = commands.NewPkgDep(productParser, os.Stdout)
+	commandSet["broken-release-refs"] = commands.NewBrokenReleaseRefs(productParser)
 
 	err = commandSet.Execute(command, args)
 	if err != nil {


### PR DESCRIPTION
I decided to create a separate command that checks for templates that reference releases that were not included in the tile. It seemed useful to have a command that explicitly checks for this condition as opposed to having the `deadweight` command catch it by coincidence. There are some commits in this PR that change how errors are returned so please review those before looking at the one that introduces the `broken-release-refs` command.

I'm planning to add a `nil` map key check for releases that are not in the tile so that `deadweight` will return an error instead of panicking. Since this requires some changes to tests and the return type of the function I'll add it to this PR later (https://github.com/ryanmoran/inspector/blob/712dfb4496477d11552a2a779cc85aae8a7330b7/tiles/product.go#L8). Main focus of the PR was to introduce `broken-release-refs` as a command for use in our pipelines.