### PR TITLE
returns error when product.UnusedReleaseJobs fails

### DIFF
--- a/commands/deadweight.go
+++ b/commands/deadweight.go
@@ -50,7 +50,12 @@ func (d Deadweight) Execute(args []string) error {
 	}
 
 	fmt.Fprintln(d.stdout, "\n\nThe following release jobs are not being used:")
-	for _, release := range product.UnusedReleaseJobs() {
+	releases, err := product.UnusedReleaseJobs()
+	if err != nil {
+		return err
+	}
+
+	for _, release := range releases {
 		fmt.Fprintf(d.stdout, "Release: %s\n", release.Name)
 		var jobs []string
 		for _, job := range release.Jobs {

--- a/tiles/product.go
+++ b/tiles/product.go
@@ -1,11 +1,13 @@
 package tiles
 
+import "fmt"
+
 type Product struct {
 	Metadata Metadata
 	Releases []Release
 }
 
-func (p Product) UnusedReleaseJobs() []Release {
+func (p Product) UnusedReleaseJobs() ([]Release, error) {
 	var releases []Release
 
 	jobTemplateUsageCounts := map[string]map[string]int{}
@@ -18,6 +20,9 @@ func (p Product) UnusedReleaseJobs() []Release {
 
 	for _, job := range p.Metadata.Jobs {
 		for _, template := range job.Templates {
+			if _, ok := jobTemplateUsageCounts[template.Release]; !ok {
+				return []Release{}, fmt.Errorf(`%q is not in the tile (referenced by template %q in job %q)`, template.Release, template.Name, job.Name)
+			}
 			jobTemplateUsageCounts[template.Release][template.Name]++
 		}
 	}
@@ -42,7 +47,7 @@ func (p Product) UnusedReleaseJobs() []Release {
 		}
 	}
 
-	return releases
+	return releases, nil
 }
 
 func (p Product) UnusedReleasePackages() []Release {

--- a/tiles/product_test.go
+++ b/tiles/product_test.go
@@ -1,0 +1,39 @@
+package tiles_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/ryanmoran/inspector/tiles"
+)
+
+var _ = Describe("Product", func() {
+	Describe("UnusedReleaseJobs", func() {
+		Context("when job refernces a releae that is not in the tile", func() {
+			It("returns an error", func() {
+				p := tiles.Product{
+					Metadata: tiles.Metadata{
+						Jobs: []tiles.MetadataJob{
+							{
+								Name: "some-job",
+								Templates: []tiles.MetadataJobTemplate{
+									{
+										Name:    "some-template",
+										Release: "some-release",
+									},
+								},
+							},
+						},
+					},
+					Releases: []tiles.Release{
+						{
+							Name: "some-other-release",
+						},
+					},
+				}
+
+				_, err := p.UnusedReleaseJobs()
+				Expect(err).To(MatchError(`"some-release" is not in the tile (referenced by template "some-template" in job "some-job")`))
+			})
+		})
+	})
+})


### PR DESCRIPTION
Returns error instead of panicking if the job references a release that
is not in the tile

Applies cleanly before or after merging #1.